### PR TITLE
fix: Add missed owner [no ticket]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,10 +4,9 @@
 * @Keldieva
 * @LMalushkina
 * @Yuriy-SE
+* @OlgaAutomation4
 
 # Codeowners to all the workflows
 .github/ @Elgrueber
 .github/ @Rom-T
-.github/ @Keldieva
-.github/ @OlgaAutomation4
 .github/ @sashakolsky


### PR DESCRIPTION
Missed one owner and if the user is owner of the whole files, It is not required to add the to the workflows separately.